### PR TITLE
API: Destroy Droplet Endpoints

### DIFF
--- a/DigitalOcean.API/Clients/DropletsClient.cs
+++ b/DigitalOcean.API/Clients/DropletsClient.cs
@@ -131,6 +131,34 @@ namespace DigitalOcean.API.Clients {
             return _connection.ExecuteRaw("droplets", parameters, null, Method.Delete);
         }
 
+        public Task<DestroyResources> GetDestroyResources(long dropletId) {
+            var parameters = new List<Parameter> {
+                new UrlSegmentParameter ("droplet_id", dropletId.ToString())
+            };
+            return _connection.ExecuteRequest<DestroyResources>("droplets/{droplet_id}/destroy_with_associated_resources", parameters);
+        }
+
+        public Task Destroy(long dropletId, Models.Requests.DestroyResources resources) {
+            var parameters = new List<Parameter> {
+                new UrlSegmentParameter ("droplet_id", dropletId.ToString())
+            };
+            return _connection.ExecuteRaw("droplets/{droplet_id}/destroy_with_associated_resources/selective", parameters, resources, Method.Delete);
+        }
+
+        public Task<DestroyStatus> GetDestroyStatus(long dropletId) {
+            var parameters = new List<Parameter> {
+                new UrlSegmentParameter ("droplet_id", dropletId.ToString())
+            };
+            return _connection.ExecuteRequest<DestroyStatus>("droplets/{droplet_id}/destroy_with_associated_resources/status", parameters);
+        }
+
+        public Task RetryDestroy(long dropletId) {
+            var parameters = new List<Parameter> {
+                new UrlSegmentParameter ("droplet_id", dropletId.ToString())
+            };
+            return _connection.ExecuteRaw("droplets/{droplet_id}/destroy_with_associated_resources/retry", parameters, method: Method.Post);
+        }
+
         /// <summary>
         /// To retrieve a list of any Droplets that are running on the same physical hardware.
         /// </summary>

--- a/DigitalOcean.API/Clients/IDropletsClient.cs
+++ b/DigitalOcean.API/Clients/IDropletsClient.cs
@@ -67,6 +67,32 @@ namespace DigitalOcean.API.Clients {
         Task DeleteByTag(string tagName);
 
         /// <summary>
+        /// To list the associated billable resources that can be destroyed along with a Droplet.
+        /// The response will contain snapshots, volumes, and volume_snapshots keys.
+        /// Each will be set to an array of objects containing information about the associated resources.
+        /// </summary>
+        Task<DestroyResources> GetDestroyResources(long dropletId);
+
+        /// <summary>
+        /// To destroy a Droplet along with a sub-set of its associated resources.
+        /// The body of the request should include reserved_ips, snapshots, volumes, or volume_snapshots keys each set to an array of IDs for the associated resources to be destroyed.
+        /// The IDs can be found by querying the Droplet's associated resources. Any associated resource not included in the request will remain and continue to accrue changes on your account.
+        /// Use the status endpoint to check on the success or failure of the destruction of the individual resources.
+        /// </summary>
+        Task Destroy(long dropletId, Models.Requests.DestroyResources resources);
+
+        /// <summary>
+        /// To check on the status of a request to destroy a Droplet with its associated resources.
+        /// </summary>
+        Task<DestroyStatus> GetDestroyStatus(long dropletId);
+
+        /// <summary>
+        /// If the status of a request to destroy a Droplet with its associated resources reported any errors, it can be retried.
+        /// Only one destroy can be active at a time per Droplet.
+        /// </summary>
+        Task RetryDestroy(long dropletId);
+
+        /// <summary>
         /// To retrieve a list of any Droplets that are running on the same physical hardware.
         /// </summary>
         [System.Obsolete("Deprecated on December 17th, 2019")]

--- a/DigitalOcean.API/Models/Requests/DestroyResources.cs
+++ b/DigitalOcean.API/Models/Requests/DestroyResources.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace DigitalOcean.API.Models.Requests;
+
+public class DestroyResources {
+
+    // DEPRECATED
+    //[JsonProperty("floating_ips")]
+    //public List<string> FloatingIps { get; set; }
+
+    /// <summary>
+    /// An array of unique identifiers for the reserved IPs to be scheduled for deletion.
+    /// </summary>
+    [JsonProperty("reserved_ips")]
+    public List<string> ReservedIps { get; set; }
+
+    /// <summary>
+    /// An array of unique identifiers for the snapshots to be scheduled for deletion.
+    /// </summary>
+    [JsonProperty("snapshots")]
+    public List<string> Snapshots { get; set; }
+
+    /// <summary>
+    /// An array of unique identifiers for the volumes to be scheduled for deletion.
+    /// </summary>
+    [JsonProperty("volumes")]
+    public List<string> Volumes { get; set; }
+
+    /// <summary>
+    /// An array of unique identifiers for the volume snapshots to be scheduled for deletion.
+    /// </summary>
+    [JsonProperty("volume_snapshots")]
+    public List<string> VolumeSnapshots { get; set; }
+}

--- a/DigitalOcean.API/Models/Responses/DestroyResources.cs
+++ b/DigitalOcean.API/Models/Responses/DestroyResources.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace DigitalOcean.API.Models.Responses;
+
+public class DestroyResources {
+
+    [JsonProperty("floating_ips")]
+    public List<DestroyResource> FloatingIps { get; set; }
+
+    [JsonProperty("reserved_ips")]
+    public List<DestroyResource> ReservedIps { get; set; }
+
+    [JsonProperty("snapshots")]
+    public List<DestroyResource> Snapshots { get; set; }
+
+    [JsonProperty("volumes")]
+    public List<DestroyResource> Volumes { get; set; }
+
+    [JsonProperty("volume_snapshots")]
+    public List<DestroyResource> VolumeSnapshots { get; set; }
+}
+
+public class DestroyResource {
+    /// <summary>
+    /// The unique identifier for the resource associated with the Droplet.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// The name of the resource associated with the Droplet.
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// The cost of the resource in USD per month if the resource is retained after the Droplet is destroyed.
+    /// </summary>
+    [JsonProperty("cost")]
+    public string Cost { get; set; }
+}

--- a/DigitalOcean.API/Models/Responses/DestroyStatus.cs
+++ b/DigitalOcean.API/Models/Responses/DestroyStatus.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace DigitalOcean.API.Models.Responses;
+
+public class DestroyStatus {
+
+    /// <summary>
+    /// An object containing information about a resource scheduled for deletion.
+    /// </summary>
+    [JsonProperty("droplet")]
+    public DestroyItemStatus Droplet { get; set; }
+
+    /// <summary>
+    /// An object containing additional information about resource related to a Droplet requested to be destroyed.
+    /// </summary>
+    [JsonProperty("resources")]
+    public DestroyStatusResources Resources { get; set; }
+
+    /// <summary>
+    /// A time value given in ISO8601 combined date and time format indicating when the requested action was completed.
+    /// </summary>
+    [JsonProperty("completed_at")]
+    public string CompletedAt { get; set; }
+
+    /// <summary>
+    /// A count of the associated resources that failed to be destroyed, if any.
+    /// </summary>
+    [JsonProperty("failures")]
+    public int Failures { get; set; }
+}
+
+public class DestroyItemStatus {
+
+    /// <summary>
+    /// The unique identifier for the resource scheduled for deletion.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// The name of the resource scheduled for deletion.
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// A time value given in ISO8601 combined date and time format indicating when the resource was destroyed if the request was successful.
+    /// </summary>
+    [JsonProperty("destroyed_at")]
+    public string DestroyedAt { get; set; }
+
+    /// <summary>
+    /// A string indicating that the resource was not successfully destroyed and providing additional information.
+    /// </summary>
+    [JsonProperty("error_message")]
+    public string ErrorMessage { get; set; }
+}
+
+public class DestroyStatusResources {
+
+    [JsonProperty("floating_ips")]
+    public List<DestroyItemStatus> FloatingIps { get; set; }
+
+    [JsonProperty("reserved_ips")]
+    public List<DestroyItemStatus> ReservedIps { get; set; }
+
+    [JsonProperty("snapshots")]
+    public List<DestroyItemStatus> Snapshots { get; set; }
+
+    [JsonProperty("volumes")]
+    public List<DestroyItemStatus> Volumes { get; set; }
+
+    [JsonProperty("volume_snapshots")]
+    public List<DestroyItemStatus> VolumeSnapshots { get; set; }
+}


### PR DESCRIPTION
add calls for 4 destroy droplet endpoints:
* get droplet resources for usage with destroy - https://docs.digitalocean.com/reference/api/api-reference/#operation/droplets_list_associatedResources
* destroy droplet with resources - https://docs.digitalocean.com/reference/api/api-reference/#operation/droplets_destroy_withAssociatedResourcesSelective
* status destroy droplet - https://docs.digitalocean.com/reference/api/api-reference/#operation/droplets_get_DestroyAssociatedResourcesStatus
* retry destroy droplet - https://docs.digitalocean.com/reference/api/api-reference/#operation/droplets_destroy_retryWithAssociatedResources

