### PR TITLE
Fix: Volumes paginated

### DIFF
--- a/DigitalOcean.API/DigitalOceanClient.cs
+++ b/DigitalOcean.API/DigitalOceanClient.cs
@@ -5,7 +5,9 @@ using RestSharp.Serializers.NewtonsoftJson;
 
 namespace DigitalOcean.API {
     public class DigitalOceanClient : IDigitalOceanClient {
-        public static readonly string DigitalOceanApiUrl = "https://api.digitalocean.com/v2/";
+        // some APIs return only a relative URL of next paginated call
+        public const string RelativeUrl = "/v2/";
+        public const string DigitalOceanApiUrl = "https://api.digitalocean.com" + RelativeUrl;
         private readonly IConnection _connection;
 
         public DigitalOceanClient(string token) {

--- a/DigitalOcean.API/Http/Connection.cs
+++ b/DigitalOcean.API/Http/Connection.cs
@@ -65,14 +65,14 @@ namespace DigitalOcean.API.Http {
                 // some APIs seem to return the full URL in paginated links (or there is some code populating this?
                 // but others (notably /v2/volumes) returns only the relative URL
                 // maybe this was a bug introduced by DO? or it has always been this way, unknown
-                var absoluteIndex = endpoint.IndexOf(DigitalOceanClient.DigitalOceanApiUrl, StringComparison.Ordinal);
+                var absoluteIndex = page.Pages.Next.IndexOf(DigitalOceanClient.DigitalOceanApiUrl, StringComparison.Ordinal);
                 if (absoluteIndex == 0) {
                     // standard replacement of full URL (only if matches from beginning of string)
                     endpoint = page.Pages.Next.Substring(DigitalOceanClient.DigitalOceanApiUrl.Length);
                 }
                 else {
                     // test if relative URL replacement, and only replace from beginning of string
-                    var relativeIndex = endpoint.IndexOf(DigitalOceanClient.RelativeUrl, StringComparison.Ordinal);
+                    var relativeIndex = page.Pages.Next.IndexOf(DigitalOceanClient.RelativeUrl, StringComparison.Ordinal);
                     if (relativeIndex == 0) {
                         endpoint = page.Pages.Next.Substring(DigitalOceanClient.RelativeUrl.Length);
                     }


### PR DESCRIPTION
Noticed the Volumes list calls (`/v2/volumes`) returns the the paginated links section as relative URLs and not absolute.

```
  "links": {
    "pages": {
      "next": "/v2/volumes?page=2",
      "last": "/v2/volumes?page=10"
    }
  },
```

Is this a DO API bug? Or has it always been this way? We haven't used volumes up till this point, primarily Droplets. Which have always returned an absolute URL in their `links` section.

Slight fixes to generating next page call, will now safely allow both.