### PR TITLE
update RestSharp to 113.1.0

### DIFF
--- a/DigitalOcean.API/DigitalOcean.API.csproj
+++ b/DigitalOcean.API/DigitalOcean.API.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <None Include="icon.png" Pack="true" Visible="false" PackagePath="" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="RestSharp" Version="112.1.0" />
-    <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="112.1.0" />
+    <PackageReference Include="RestSharp" Version="113.1.0" />
+    <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="113.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
ABI breaking change in UrlSegmentParameter constructor
https://github.com/restsharp/RestSharp/pull/2265/changes

Just need to recompile against newest RestSharp.