### PR TITLE
Use Parameter.CreateParameter() factory pattern

### DIFF
--- a/DigitalOcean.API/Clients/ActionsClient.cs
+++ b/DigitalOcean.API/Clients/ActionsClient.cs
@@ -26,7 +26,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Get(long actionId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", actionId.ToString())
+                Parameter.CreateParameter("id", actionId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Action>("actions/{id}", parameters, null, "action");
         }

--- a/DigitalOcean.API/Clients/AppsClient.cs
+++ b/DigitalOcean.API/Clients/AppsClient.cs
@@ -22,22 +22,22 @@ namespace DigitalOcean.API.Clients {
 
         public Task<App> RetrieveExistingApp(string appId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("appId", appId)
+                Parameter.CreateParameter("appId", appId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<App>("apps/{appId}", parameters, null, "app");
         }
 
         public Task<IReadOnlyList<Deployment>> ListAppDeployments(string appId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("appId", appId)
+                Parameter.CreateParameter("appId", appId, ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<Deployment>("apps/{appId}/deployments", parameters, "deployments");
         }
 
         public Task<Deployment> RetrieveAppDeployment(string appId, string deploymentId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("appId", appId),
-                new UrlSegmentParameter("deploymentId", deploymentId)
+                Parameter.CreateParameter("appId", appId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("deploymentId", deploymentId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Deployment>("apps/{appId}/deployments/{deploymentId}", parameters, null,
                 "deployment");
@@ -45,7 +45,7 @@ namespace DigitalOcean.API.Clients {
 
         public Task DeleteApp(string appId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("appId", appId)
+                Parameter.CreateParameter("appId", appId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("apps/{appId}", parameters, null, Method.Delete);
         }
@@ -56,7 +56,7 @@ namespace DigitalOcean.API.Clients {
 
         public Task<Deployment> CreateNewDeployment(string appId, ForceBuildApp forceBuild) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("appId", appId)
+                Parameter.CreateParameter("appId", appId, ParameterType.UrlSegment)
             };
 
             return _connection.ExecuteRequest<Deployment>("apps/{appId}/deployments", parameters,
@@ -65,8 +65,8 @@ namespace DigitalOcean.API.Clients {
 
         public Task<Deployment> CancelDeployment(string appId, string deploymentId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("appId", appId),
-                new UrlSegmentParameter("deploymentId", deploymentId)
+                Parameter.CreateParameter("appId", appId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("deploymentId", deploymentId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Deployment>("apps/{appId}/deployments/{deploymentId}", parameters, null,
                 "deployment", Method.Post);

--- a/DigitalOcean.API/Clients/CdnEndpointsClient.cs
+++ b/DigitalOcean.API/Clients/CdnEndpointsClient.cs
@@ -24,7 +24,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<CdnEndpoint> Get(string endpointId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("endpoint_id", endpointId)
+                Parameter.CreateParameter("endpoint_id", endpointId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<CdnEndpoint>("cdn/endpoints/{endpoint_id}", parameters, null, "endpoint");
         }
@@ -42,7 +42,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<CdnEndpoint> Update(string endpointId, Models.Requests.UpdateCdnEndpoint updateEndpoint) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("endpoint_id", endpointId)
+                Parameter.CreateParameter("endpoint_id", endpointId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<CdnEndpoint>("cdn/endpoints/{endpoint_id}", parameters, updateEndpoint, "endpoint", Method.Put);
         }
@@ -52,7 +52,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string endpointId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("endpoint_id", endpointId)
+                Parameter.CreateParameter("endpoint_id", endpointId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("cdn/endpoints/{endpoint_id}", parameters, null, Method.Delete);
         }
@@ -64,7 +64,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task PurgeCache(string endpointId, Models.Requests.PurgeCdnFiles purgeFiles) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("endpoint_id", endpointId)
+                Parameter.CreateParameter("endpoint_id", endpointId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("cdn/endpoints/{endpoint_id}/cache", parameters, purgeFiles, Method.Delete);
         }

--- a/DigitalOcean.API/Clients/CertificatesClient.cs
+++ b/DigitalOcean.API/Clients/CertificatesClient.cs
@@ -24,7 +24,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Certificate> Get(string certificateId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("certificate_id", certificateId)
+                Parameter.CreateParameter("certificate_id", certificateId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Certificate>("certificates/{certificate_id}", parameters, null, "certificate");
         }
@@ -47,7 +47,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string certificateId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("certificate_id", certificateId)
+                Parameter.CreateParameter("certificate_id", certificateId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("certificates/{certificate_id}", parameters, null, Method.Delete);
         }

--- a/DigitalOcean.API/Clients/ContainerRegistryClient.cs
+++ b/DigitalOcean.API/Clients/ContainerRegistryClient.cs
@@ -71,7 +71,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<ContainerRegistryRepository>> GetAllRepositories(string registryName) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter (nameof(registryName), registryName)
+                Parameter.CreateParameter(nameof(registryName), registryName, ParameterType.UrlSegment)
             };
 
             return _connection.GetPaginated<ContainerRegistryRepository>($"registry/{{{nameof(registryName)}}}/repositories", parameters, "repositories");
@@ -82,8 +82,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<ContainerRegistryTag>> GetAllRepositoryTags(string registryName, string repositoryName) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter (nameof(registryName), registryName),
-                new UrlSegmentParameter (nameof(repositoryName), repositoryName),
+                Parameter.CreateParameter(nameof(registryName), registryName, ParameterType.UrlSegment),
+                Parameter.CreateParameter(nameof(repositoryName), repositoryName, ParameterType.UrlSegment),
             };
 
             return _connection.GetPaginated<ContainerRegistryTag>($"registry/{{{nameof(registryName)}}}/repositories/{{{nameof(repositoryName)}}}/tags", parameters, "tags");
@@ -94,9 +94,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task DeleteRepositoryTag(string registryName, string repositoryName, string tag) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter (nameof(registryName), registryName),
-                new UrlSegmentParameter (nameof(repositoryName), repositoryName),
-                new UrlSegmentParameter (nameof(tag), tag),
+                Parameter.CreateParameter(nameof(registryName), registryName, ParameterType.UrlSegment),
+                Parameter.CreateParameter(nameof(repositoryName), repositoryName, ParameterType.UrlSegment),
+                Parameter.CreateParameter(nameof(tag), tag, ParameterType.UrlSegment),
             };
 
             return _connection.ExecuteRaw($"registry/{{{nameof(registryName)}}}/repositories/{{{nameof(repositoryName)}}}/tags/{{{nameof(tag)}}}", parameters, null, Method.Delete);
@@ -107,8 +107,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task DeleteRepositoryManifest(string registryName, string repositoryName, string manifestDigest) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter (nameof(registryName), registryName),
-                new UrlSegmentParameter (nameof(repositoryName), repositoryName),
+                Parameter.CreateParameter(nameof(registryName), registryName, ParameterType.UrlSegment),
+                Parameter.CreateParameter(nameof(repositoryName), repositoryName, ParameterType.UrlSegment),
             };
 
             return _connection.ExecuteRaw($"registry/{{{nameof(registryName)}}}/repositories/{{{nameof(repositoryName)}}}/digests/{manifestDigest}", parameters, null, Method.Delete);
@@ -119,7 +119,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<GarbageCollection> StartGarbageCollection(string registryName) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter (nameof(registryName), registryName),
+                Parameter.CreateParameter(nameof(registryName), registryName, ParameterType.UrlSegment),
             };
 
             return _connection.ExecuteRequest<GarbageCollection>($"registry/{{{nameof(registryName)}}}/garbage-collection", parameters, null, "garbage_collections", Method.Post);
@@ -130,7 +130,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<GarbageCollection> GetActiveGarbageCollection(string registryName) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter (nameof(registryName), registryName),
+                Parameter.CreateParameter(nameof(registryName), registryName, ParameterType.UrlSegment),
             };
 
             return _connection.ExecuteRequest<GarbageCollection>($"registry/{{{nameof(registryName)}}}/garbage-collection", parameters, null, "garbage_collections");
@@ -141,7 +141,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<GarbageCollection>> GetAllGarbageCollections(string registryName) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter (nameof(registryName), registryName),
+                Parameter.CreateParameter(nameof(registryName), registryName, ParameterType.UrlSegment),
             };
 
             return _connection.GetPaginated<GarbageCollection>($"registry/{{{nameof(registryName)}}}/garbage-collections", parameters, "garbage_collections");
@@ -152,8 +152,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<GarbageCollection> UpdateGarbageCollection(string registryName, string uuid, UpdateGarbageCollection updateGarbageCollection) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter (nameof(registryName), registryName),
-                new UrlSegmentParameter (nameof(uuid), uuid),
+                Parameter.CreateParameter(nameof(registryName), registryName, ParameterType.UrlSegment),
+                Parameter.CreateParameter(nameof(uuid), uuid, ParameterType.UrlSegment),
             };
 
             return _connection.ExecuteRequest<GarbageCollection>($"registry/{{{nameof(registryName)}}}/garbage-collection/{{{nameof(uuid)}}}", parameters, updateGarbageCollection, "garbage_collections", Method.Put);

--- a/DigitalOcean.API/Clients/DatabasesClient.cs
+++ b/DigitalOcean.API/Clients/DatabasesClient.cs
@@ -19,7 +19,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<ConnectionPool> AddConnectionPool(string databaseId, Models.Requests.ConnectionPool pool) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<ConnectionPool>("databases/{id}/pools", parameters, pool, "pool", Method.Post);
         }
@@ -29,7 +29,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Database> AddDatabase(string databaseId, Models.Requests.Database database) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Database>("databases/{id}/dbs", parameters, database, "db", Method.Post);
         }
@@ -39,7 +39,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DatabaseUser> AddUser(string databaseId, Models.Requests.DatabaseUser user) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<DatabaseUser>("databases/{id}/users", parameters, user, "user", Method.Post);
         }
@@ -56,7 +56,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DatabaseReplica> CreateReplica(string databaseId, Models.Requests.DatabaseReplica replica) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<DatabaseReplica>("databases/{id}/replicas", parameters, replica, "replica", Method.Post);
         }
@@ -66,7 +66,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string databaseId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("databases/{id}", parameters, null, Method.Delete);
         }
@@ -76,8 +76,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task DeleteConnectionPool(string databaseId, string poolName) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId),
-                new UrlSegmentParameter("name", poolName)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("name", poolName, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("databases/{id}/pools/{name}", parameters, null, Method.Delete);
         }
@@ -87,8 +87,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task DeleteDatabase(string databaseId, string databaseName) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId),
-                new UrlSegmentParameter("name", databaseName)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("name", databaseName, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("databases/{id}/dbs/{name}", parameters, null, Method.Delete);
         }
@@ -98,8 +98,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task DeleteReplica(string databaseId, string replicaName) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId),
-                new UrlSegmentParameter("name", replicaName)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("name", replicaName, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("databases/{id}/replicas/{name}", parameters, null, Method.Delete);
         }
@@ -109,7 +109,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DatabaseCluster> Get(string databaseId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<DatabaseCluster>("databases/{id}", parameters, null, "database");
         }
@@ -136,7 +136,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<DatabaseReplica>> GetAllReplicas(string databaseId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<DatabaseReplica>("databases/{id}/replicas", parameters, "replicas");
         }
@@ -146,7 +146,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<ConnectionPool>> GetAllConnectionPools(string databaseId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<ConnectionPool>("databases/{id}/pools", parameters, "pools");
         }
@@ -156,7 +156,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Database>> GetAllDatabases(string databaseId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<Database>("databases/{id}/dbs", parameters, "dbs");
         }
@@ -166,7 +166,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<DatabaseUser>> GetAllUsers(string databaseId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<DatabaseUser>("databases/{id}/users", parameters, "users");
         }
@@ -176,7 +176,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<DatabaseBackup>> GetBackups(string databaseId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<DatabaseBackup>("databases/{id}/backups", parameters, "backups");
         }
@@ -186,8 +186,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<ConnectionPool> GetConnectionPool(string databaseId, string poolName) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId),
-                new UrlSegmentParameter("name", poolName)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("name", poolName, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<ConnectionPool>("databases/{id}/pools/{name}", parameters, null, "pool");
         }
@@ -197,8 +197,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Database> GetDatabase(string databaseId, string databaseName) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId),
-                new UrlSegmentParameter("name", databaseName)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("name", databaseName, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Database>("databases/{id}/dbs/{name}", parameters, null, "db");
         }
@@ -208,8 +208,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DatabaseReplica> GetReplica(string databaseId, string replicaName) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId),
-                new UrlSegmentParameter("name", replicaName)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("name", replicaName, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<DatabaseReplica>("databases/{id}/replicas/{name}", parameters, null, "replica");
         }
@@ -219,8 +219,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DatabaseUser> GetUser(string databaseId, string username) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId),
-                new UrlSegmentParameter("name", username)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("name", username, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<DatabaseUser>("databases/{id}/users/{name}", parameters, null, "user");
         }
@@ -230,7 +230,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Maintenance(string databaseId, Models.Requests.MaintenanceWindow window) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("databases/{id}/maintenance", parameters, window, Method.Post);
         }
@@ -240,7 +240,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Migrate(string databaseId, Models.Requests.MigrateDatabase migrate) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("databases/{id}/migrate", parameters, migrate, Method.Post);
         }
@@ -250,8 +250,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task RemoveUser(string databaseId, string username) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId),
-                new UrlSegmentParameter("name", username)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("name", username, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("databases/{id}/users/{name}", parameters, null, Method.Delete);
         }
@@ -262,8 +262,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DatabaseUser> ResetUserAuth(string databaseId, string username, Models.Requests.DatabaseResetUserAuth resetAuth) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId),
-                new UrlSegmentParameter("username", username)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("username", username, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<DatabaseUser>("databases/{id}/users/{username}/reset_auth", parameters, resetAuth, "user", Method.Post);
         }
@@ -273,7 +273,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Resize(string databaseId, Models.Requests.ResizeDatabase resize) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("databases/{id}/resize", parameters, resize, Method.Post);
         }
@@ -293,7 +293,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task UpdateFirewallRules(string databaseId, Models.Requests.UpdateDatabaseFirewallRules updateRules) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("databases/{id}/firewall", parameters, updateRules, Method.Put);
         }
@@ -303,7 +303,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<DatabaseFirewallRule>> ListFirewallRules(string databaseId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<DatabaseFirewallRule>("databases/{id}/firewall", parameters, "rules");
         }
@@ -313,7 +313,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<RedisEvictionPolicy> RetrieveEvictionPolicy(string databaseId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<RedisEvictionPolicy>("databases/{id}/eviction_policy", parameters, null, null);
         }
@@ -323,7 +323,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task ConfigureEvictionPolicy(string databaseId, Models.Requests.RedisEvictionPolicy evictionPolicy) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("databases/{id}/eviction_policy", parameters, evictionPolicy, Method.Put);
         }
@@ -333,7 +333,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<MySqlModes> RetrieveSqlModes(string databaseId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<MySqlModes>("databases/{id}/sql_mode", parameters, null, null);
         }
@@ -344,7 +344,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task ConfigureSqlModes(string databaseId, Models.Requests.MySqlModes sqlModes) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", databaseId)
+                Parameter.CreateParameter("id", databaseId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("databases/{id}/sql_mode", parameters, sqlModes, Method.Put);
         }

--- a/DigitalOcean.API/Clients/DomainRecordsClient.cs
+++ b/DigitalOcean.API/Clients/DomainRecordsClient.cs
@@ -20,7 +20,7 @@ namespace DigitalOcean.API.Clients {
         public Task<IReadOnlyList<DomainRecord>> GetAll(string domainName) {
             // docs don't say this is paginated? but it could be so run it thru that anyway
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("name", domainName)
+                Parameter.CreateParameter("name", domainName, ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<DomainRecord>("domains/{name}/records", parameters, "domain_records");
         }
@@ -30,7 +30,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DomainRecord> Create(string domainName, Models.Requests.DomainRecord record) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("name", domainName)
+                Parameter.CreateParameter("name", domainName, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<DomainRecord>("domains/{name}/records", parameters, record,
                 "domain_record", Method.Post);
@@ -41,8 +41,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DomainRecord> Get(string domainName, long recordId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("name", domainName),
-                new UrlSegmentParameter ("id", recordId.ToString())
+                Parameter.CreateParameter("name", domainName, ParameterType.UrlSegment),
+                Parameter.CreateParameter("id", recordId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<DomainRecord>("domains/{name}/records/{id}", parameters, null, "domain_record");
         }
@@ -52,8 +52,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string domainName, long recordId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("name", domainName),
-                new UrlSegmentParameter ("id", recordId.ToString())
+                Parameter.CreateParameter("name", domainName, ParameterType.UrlSegment),
+                Parameter.CreateParameter("id", recordId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("domains/{name}/records/{id}", parameters, null, Method.Delete);
         }
@@ -63,8 +63,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DomainRecord> Update(string domainName, long recordId, Models.Requests.UpdateDomainRecord updateRecord) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("name", domainName),
-                new UrlSegmentParameter ("id", recordId.ToString())
+                Parameter.CreateParameter("name", domainName, ParameterType.UrlSegment),
+                Parameter.CreateParameter("id", recordId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<DomainRecord>("domains/{name}/records/{id}", parameters, updateRecord,
                 "domain_record", Method.Put);

--- a/DigitalOcean.API/Clients/DomainsClient.cs
+++ b/DigitalOcean.API/Clients/DomainsClient.cs
@@ -34,7 +34,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Domain> Get(string domainName) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("name", domainName)
+                Parameter.CreateParameter("name", domainName, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Domain>("domains/{name}", parameters, null, "domain");
         }
@@ -44,7 +44,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string domainName) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("name", domainName)
+                Parameter.CreateParameter("name", domainName, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("domains/{name}", parameters, null, Method.Delete);
         }

--- a/DigitalOcean.API/Clients/DropletActionsClient.cs
+++ b/DigitalOcean.API/Clients/DropletActionsClient.cs
@@ -20,7 +20,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Reboot(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("dropletId", dropletId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
             };
             var body = new Models.Requests.DropletAction { Type = "reboot" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
@@ -32,7 +32,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> PowerCycle(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("dropletId", dropletId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
             };
             var body = new Models.Requests.DropletAction { Type = "power_cycle" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
@@ -44,7 +44,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Shutdown(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("dropletId", dropletId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
             };
             var body = new Models.Requests.DropletAction { Type = "shutdown" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
@@ -56,7 +56,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> PowerOff(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("dropletId", dropletId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
             };
             var body = new Models.Requests.DropletAction { Type = "power_off" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
@@ -68,7 +68,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> PowerOn(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("dropletId", dropletId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
             };
             var body = new Models.Requests.DropletAction { Type = "power_on" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
@@ -80,7 +80,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> ResetPassword(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("dropletId", dropletId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
             };
             var body = new Models.Requests.DropletAction { Type = "password_reset" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
@@ -92,7 +92,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Resize(long dropletId, string sizeSlug, bool resizeDisk) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("dropletId", dropletId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
             };
             var body = new Models.Requests.DropletAction {
                 Type = "resize",
@@ -110,7 +110,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Restore(long dropletId, object imageIdOrSlug) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("dropletId", dropletId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
             };
             var body = new Models.Requests.DropletAction {
                 Type = "restore",
@@ -125,7 +125,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Rebuild(long dropletId, object imageIdOrSlug) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("dropletId", dropletId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
             };
             var body = new Models.Requests.DropletAction {
                 Type = "rebuild",
@@ -140,7 +140,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Rename(long dropletId, string name) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("dropletId", dropletId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
             };
             var body = new Models.Requests.DropletAction {
                 Type = "rename",
@@ -155,7 +155,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> ChangeKernel(long dropletId, long kernelId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("dropletId", dropletId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
             };
             var body = new Models.Requests.DropletAction {
                 Type = "change_kernel",
@@ -170,7 +170,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> EnableIpv6(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("dropletId", dropletId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
             };
             var body = new Models.Requests.DropletAction { Type = "enable_ipv6" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
@@ -182,7 +182,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> EnableBackups(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("dropletId", dropletId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
             };
             var body = new Models.Requests.DropletAction { Type = "enable_backups" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
@@ -194,7 +194,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> DisableBackups(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("dropletId", dropletId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
             };
             var body = new Models.Requests.DropletAction { Type = "disable_backups" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
@@ -206,7 +206,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> EnablePrivateNetworking(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("dropletId", dropletId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
             };
             var body = new Models.Requests.DropletAction { Type = "enable_private_networking" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
@@ -218,7 +218,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Snapshot(long dropletId, string name) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("dropletId", dropletId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
             };
             var body = new Models.Requests.DropletAction {
                 Type = "snapshot",
@@ -233,8 +233,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> GetDropletAction(long dropletId, long actionId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("dropletId", dropletId.ToString()),
-                new UrlSegmentParameter ("actionId", actionId.ToString())
+                Parameter.CreateParameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment),
+                Parameter.CreateParameter("actionId", actionId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions/{actionId}", parameters,
                 null, "action");

--- a/DigitalOcean.API/Clients/DropletsClient.cs
+++ b/DigitalOcean.API/Clients/DropletsClient.cs
@@ -38,7 +38,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Droplet>> GetAllNeighbors(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", dropletId.ToString())
+                Parameter.CreateParameter("id", dropletId.ToString(), ParameterType.UrlSegment)
             };
 
             return _connection.GetPaginated<Droplet>("droplets/{id}/neighbors", parameters, "droplets");
@@ -49,7 +49,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Kernel>> GetKernels(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", dropletId.ToString())
+                Parameter.CreateParameter("id", dropletId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<Kernel>("droplets/{id}/kernels", parameters, "kernels");
         }
@@ -59,7 +59,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Image>> GetSnapshots(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", dropletId.ToString())
+                Parameter.CreateParameter("id", dropletId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<Image>("droplets/{id}/snapshots", parameters, "snapshots");
         }
@@ -69,7 +69,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Image>> GetBackups(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", dropletId.ToString())
+                Parameter.CreateParameter("id", dropletId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<Image>("droplets/{id}/backups", parameters, "backups");
         }
@@ -79,7 +79,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Action>> GetActions(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", dropletId.ToString())
+                Parameter.CreateParameter("id", dropletId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<Action>("droplets/{id}/actions", parameters, "actions");
         }
@@ -106,7 +106,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Droplet> Get(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", dropletId.ToString())
+                Parameter.CreateParameter("id", dropletId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Droplet>("droplets/{id}", parameters, null, "droplet");
         }
@@ -116,7 +116,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", dropletId.ToString())
+                Parameter.CreateParameter("id", dropletId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("droplets/{id}", parameters, null, Method.Delete);
         }
@@ -133,28 +133,28 @@ namespace DigitalOcean.API.Clients {
 
         public Task<DestroyResources> GetDestroyResources(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("droplet_id", dropletId.ToString())
+                Parameter.CreateParameter("droplet_id", dropletId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<DestroyResources>("droplets/{droplet_id}/destroy_with_associated_resources", parameters);
         }
 
         public Task Destroy(long dropletId, Models.Requests.DestroyResources resources) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("droplet_id", dropletId.ToString())
+                Parameter.CreateParameter("droplet_id", dropletId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("droplets/{droplet_id}/destroy_with_associated_resources/selective", parameters, resources, Method.Delete);
         }
 
         public Task<DestroyStatus> GetDestroyStatus(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("droplet_id", dropletId.ToString())
+                Parameter.CreateParameter("droplet_id", dropletId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<DestroyStatus>("droplets/{droplet_id}/destroy_with_associated_resources/status", parameters);
         }
 
         public Task RetryDestroy(long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("droplet_id", dropletId.ToString())
+                Parameter.CreateParameter("droplet_id", dropletId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("droplets/{droplet_id}/destroy_with_associated_resources/retry", parameters, method: Method.Post);
         }

--- a/DigitalOcean.API/Clients/FirewallsClient.cs
+++ b/DigitalOcean.API/Clients/FirewallsClient.cs
@@ -17,7 +17,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task AddDroplets(string firewallId, Models.Requests.FirewallDroplets droplets) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", firewallId)
+                Parameter.CreateParameter("id", firewallId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("firewalls/{id}/droplets", parameters, droplets, Method.Post);
         }
@@ -27,7 +27,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task AddRules(string firewallId, Models.Requests.FirewallRules rules) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", firewallId)
+                Parameter.CreateParameter("id", firewallId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("firewalls/{id}/rules", parameters, rules, Method.Post);
         }
@@ -37,7 +37,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task AddTags(string firewallId, Models.Requests.FirewallTags tags) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", firewallId)
+                Parameter.CreateParameter("id", firewallId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("firewalls/{id}/tags", parameters, tags, Method.Post);
         }
@@ -54,7 +54,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string firewallId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", firewallId)
+                Parameter.CreateParameter("id", firewallId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("firewalls/{id}", parameters, null, Method.Delete);
         }
@@ -64,7 +64,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Firewall> Get(string firewallId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", firewallId)
+                Parameter.CreateParameter("id", firewallId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Firewall>("firewalls/{id}", parameters, null, "firewall");
         }
@@ -81,7 +81,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task RemoveDroplets(string firewallId, Models.Requests.FirewallDroplets droplets) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", firewallId)
+                Parameter.CreateParameter("id", firewallId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("firewalls/{id}/droplets", parameters, droplets, Method.Delete);
         }
@@ -91,7 +91,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task RemoveRules(string firewallId, Models.Requests.FirewallRules rules) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", firewallId)
+                Parameter.CreateParameter("id", firewallId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("firewalls/{id}/rules", parameters, rules, Method.Delete);
         }
@@ -101,7 +101,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task RemoveTags(string firewallId, Models.Requests.FirewallTags tags) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", firewallId)
+                Parameter.CreateParameter("id", firewallId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("firewalls/{id}/tags", parameters, tags, Method.Delete);
         }
@@ -111,7 +111,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Firewall> Update(string firewallId, Models.Requests.Firewall firewall) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", firewallId)
+                Parameter.CreateParameter("id", firewallId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Firewall>("firewalls/{id}", parameters, firewall, "firewall", Method.Put);
         }

--- a/DigitalOcean.API/Clients/FloatingIpActionsClient.cs
+++ b/DigitalOcean.API/Clients/FloatingIpActionsClient.cs
@@ -17,7 +17,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Assign(string ipAddress, long dropletId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("ip", ipAddress)
+                Parameter.CreateParameter("ip", ipAddress, ParameterType.UrlSegment)
             };
             var body = new Models.Requests.FloatingIpAction {
                 Type = "assign",
@@ -31,8 +31,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> GetAction(string ipAddress, long actionId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("ip", ipAddress),
-                new UrlSegmentParameter ("actionId", actionId.ToString())
+                Parameter.CreateParameter("ip", ipAddress, ParameterType.UrlSegment),
+                Parameter.CreateParameter("actionId", actionId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Action>("floating_ips/{ip}/actions/{actionId}", parameters, null, "action");
         }
@@ -42,7 +42,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Action>> GetActions(string ipAddress) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("ip", ipAddress)
+                Parameter.CreateParameter("ip", ipAddress, ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<Action>("floating_ips/{ip}/actions", parameters, "actions");
         }
@@ -52,7 +52,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Unassign(string ipAddress) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("ip", ipAddress)
+                Parameter.CreateParameter("ip", ipAddress, ParameterType.UrlSegment)
             };
             var body = new Models.Requests.FloatingIpAction {
                 Type = "unassign"

--- a/DigitalOcean.API/Clients/FloatingIpsClient.cs
+++ b/DigitalOcean.API/Clients/FloatingIpsClient.cs
@@ -24,7 +24,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string ipAddress) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("ip", ipAddress)
+                Parameter.CreateParameter("ip", ipAddress, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("floating_ips/{ip}", parameters, null, Method.Delete);
         }
@@ -34,7 +34,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<FloatingIp> Get(string ipAddress) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("ip", ipAddress)
+                Parameter.CreateParameter("ip", ipAddress, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<FloatingIp>("floating_ips/{ip}", parameters, null, "floating_ip");
         }

--- a/DigitalOcean.API/Clients/ImageActionsClient.cs
+++ b/DigitalOcean.API/Clients/ImageActionsClient.cs
@@ -19,7 +19,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Transfer(long imageId, string regionSlug) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("imageId", imageId.ToString())
+                Parameter.CreateParameter("imageId", imageId.ToString(), ParameterType.UrlSegment)
             };
 
             var body = new Models.Requests.ImageAction {
@@ -36,7 +36,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Convert(long imageId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("imageId", imageId.ToString())
+                Parameter.CreateParameter("imageId", imageId.ToString(), ParameterType.UrlSegment)
             };
 
             var body = new Models.Requests.ImageAction {
@@ -52,8 +52,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> GetAction(long imageId, long actionId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("imageId", imageId.ToString()),
-                new UrlSegmentParameter ("actionId", actionId.ToString())
+                Parameter.CreateParameter("imageId", imageId.ToString(), ParameterType.UrlSegment),
+                Parameter.CreateParameter("actionId", actionId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Action>("images/{imageId}/actions/{actionId}", parameters, null, "action");
         }

--- a/DigitalOcean.API/Clients/ImagesClient.cs
+++ b/DigitalOcean.API/Clients/ImagesClient.cs
@@ -55,7 +55,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Action>> GetAllActions(long imageId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", imageId.ToString())
+                Parameter.CreateParameter("id", imageId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<Action>("images/{id}/actions", parameters, "actions");
         }
@@ -77,7 +77,7 @@ namespace DigitalOcean.API.Clients {
         /// </remarks>
         public Task<Image> Get(object imageIdOrSlug) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", imageIdOrSlug.ToString())
+                Parameter.CreateParameter("id", imageIdOrSlug.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Image>("images/{id}", parameters, null, "image");
         }
@@ -87,7 +87,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(long imageId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", imageId.ToString())
+                Parameter.CreateParameter("id", imageId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("images/{id}", parameters, null, Method.Delete);
         }
@@ -97,7 +97,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Image> Update(long imageId, Models.Requests.UpdateImage updateImage) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", imageId.ToString())
+                Parameter.CreateParameter("id", imageId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Image>("images/{id}", parameters, updateImage, "image", Method.Put);
         }

--- a/DigitalOcean.API/Clients/KeysClient.cs
+++ b/DigitalOcean.API/Clients/KeysClient.cs
@@ -33,7 +33,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Key> Get(object keyIdOrFingerprint) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", keyIdOrFingerprint.ToString())
+                Parameter.CreateParameter("id", keyIdOrFingerprint.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Key>("account/keys/{id}", parameters, null, "ssh_key");
         }
@@ -43,7 +43,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Key> Update(object keyIdOrFingerprint, Models.Requests.UpdateKey updateKey) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", keyIdOrFingerprint.ToString())
+                Parameter.CreateParameter("id", keyIdOrFingerprint.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Key>("account/keys/{id}", parameters, updateKey, "ssh_key", Method.Put);
         }
@@ -53,7 +53,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(object keyIdOrFingerprint) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id",keyIdOrFingerprint.ToString())
+                Parameter.CreateParameter("id", keyIdOrFingerprint.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("account/keys/{id}", parameters, null, Method.Delete);
         }

--- a/DigitalOcean.API/Clients/KubernetesClient.cs
+++ b/DigitalOcean.API/Clients/KubernetesClient.cs
@@ -21,7 +21,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<KubernetesNodePool> AddNodePool(string clusterId, Models.Requests.KubernetesNodePool pool) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", clusterId)
+                Parameter.CreateParameter("id", clusterId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<KubernetesNodePool>("kubernetes/clusters/{id}/node_pools", parameters, pool, "node_pool", Method.Post);
         }
@@ -38,7 +38,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string clusterId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", clusterId)
+                Parameter.CreateParameter("id", clusterId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("kubernetes/clusters/{id}", parameters, null, Method.Delete);
         }
@@ -59,9 +59,9 @@ namespace DigitalOcean.API.Clients {
                     break;
             }
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", clusterId),
-                new UrlSegmentParameter ("poolId", poolId),
-                new UrlSegmentParameter ("nodeId", nodeId)
+                Parameter.CreateParameter("id", clusterId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("poolId", poolId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("nodeId", nodeId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw(endpoint, parameters, null, Method.Delete);
         }
@@ -71,8 +71,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task DeleteNodePool(string clusterId, string poolId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", clusterId),
-                new UrlSegmentParameter("poolId", poolId)
+                Parameter.CreateParameter("id", clusterId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("poolId", poolId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("kubernetes/clusters/{id}/node_pools/{poolId}", parameters, null, Method.Delete);
         }
@@ -82,7 +82,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<KubernetesCluster> Get(string clusterId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", clusterId)
+                Parameter.CreateParameter("id", clusterId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<KubernetesCluster>("kubernetes/clusters/{id}", parameters, null, "kubernetes_cluster");
         }
@@ -99,7 +99,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<KubernetesNodePool>> GetAllNodePools(string clusterId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", clusterId)
+                Parameter.CreateParameter("id", clusterId, ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<KubernetesNodePool>("kubernetes/clusters/{id}/node_pools", parameters, "node_pools");
         }
@@ -112,7 +112,7 @@ namespace DigitalOcean.API.Clients {
         /// </returns>
         public Task<IReadOnlyList<byte>> GetKubeConfig(string clusterId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", clusterId)
+                Parameter.CreateParameter("id", clusterId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("kubernetes/clusters/{id}/kubeconfig", parameters, null).ToByteArrayAsync();
         }
@@ -122,8 +122,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<KubernetesNodePool> GetNodePool(string clusterId, string poolId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", clusterId),
-                new UrlSegmentParameter ("poolId", poolId)
+                Parameter.CreateParameter("id", clusterId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("poolId", poolId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<KubernetesNodePool>("kubernetes/clusters/{id}/node_pools/{poolId}", parameters, null, "node_pool");
         }
@@ -140,7 +140,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<KubernetesUpgrade>> GetUpgrades(string clusterId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", clusterId)
+                Parameter.CreateParameter("id", clusterId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<List<KubernetesUpgrade>>("kubernetes/clusters/{id}/upgrades", parameters, null, "available_upgrade_versions").ToReadOnlyListAsync();
         }
@@ -150,7 +150,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<KubernetesCluster> Update(string clusterId, Models.Requests.UpdateKubernetesCluster cluster) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", clusterId)
+                Parameter.CreateParameter("id", clusterId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<KubernetesCluster>("kubernetes/clusters/{id}", parameters, cluster, "kubernetes_cluster", Method.Put);
         }
@@ -160,8 +160,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<KubernetesNodePool> UpdateNodePool(string clusterId, string poolId, Models.Requests.UpdateKubernetesNodePool pool) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", clusterId),
-                new UrlSegmentParameter("poolId", poolId)
+                Parameter.CreateParameter("id", clusterId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("poolId", poolId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<KubernetesNodePool>("kubernetes/clusters/{id}/node_pools/{poolId}", parameters, pool, "node_pool", Method.Put);
         }
@@ -171,7 +171,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Upgrade(string clusterId, Models.Requests.KubernetesUpgrade upgrade) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", clusterId)
+                Parameter.CreateParameter("id", clusterId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("kubernetes/clusters/{id}/upgrade", parameters, upgrade, Method.Post);
         }

--- a/DigitalOcean.API/Clients/LoadBalancerClient.cs
+++ b/DigitalOcean.API/Clients/LoadBalancerClient.cs
@@ -14,7 +14,7 @@ namespace DigitalOcean.API.Clients {
 
         public Task<LoadBalancer> Get(string loadBalancerId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", loadBalancerId)
+                Parameter.CreateParameter("id", loadBalancerId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<LoadBalancer>("load_balancers/{id}", parameters, null, "load_balancers");
         }
@@ -29,21 +29,21 @@ namespace DigitalOcean.API.Clients {
 
         public Task Delete(string loadBalancerId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", loadBalancerId)
+                Parameter.CreateParameter("id", loadBalancerId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("load_balancers/{id}", parameters, null, Method.Delete);
         }
 
         public Task Update(string loadBalancerId, Models.Requests.LoadBalancer loadBalancer) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", loadBalancerId)
+                Parameter.CreateParameter("id", loadBalancerId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<LoadBalancer>("load_balancers/{id}", parameters, loadBalancer, "load_balancers", Method.Put);
         }
 
         public Task AddDroplets(string loadBalancerId, Models.Requests.LoadBalancerDroplets dropletIds) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", loadBalancerId)
+                Parameter.CreateParameter("id", loadBalancerId, ParameterType.UrlSegment)
             };
 
             return _connection.ExecuteRaw("load_balancers/{id}/droplets", parameters, dropletIds, Method.Post);
@@ -51,7 +51,7 @@ namespace DigitalOcean.API.Clients {
 
         public Task RemoveDroplets(string loadBalancerId, Models.Requests.LoadBalancerDroplets dropletIds) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", loadBalancerId)
+                Parameter.CreateParameter("id", loadBalancerId, ParameterType.UrlSegment)
             };
 
             return _connection.ExecuteRaw("load_balancers/{id}/droplets", parameters, dropletIds, Method.Delete);
@@ -59,7 +59,7 @@ namespace DigitalOcean.API.Clients {
 
         public Task AddForwardingRules(string loadBalancerId, Models.Requests.ForwardingRulesList forwardingRules) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", loadBalancerId)
+                Parameter.CreateParameter("id", loadBalancerId, ParameterType.UrlSegment)
             };
 
             return _connection.ExecuteRaw("load_balancers/{id}/forwarding_rules", parameters, forwardingRules, Method.Post);
@@ -67,7 +67,7 @@ namespace DigitalOcean.API.Clients {
 
         public Task RemoveForwardingRules(string loadBalancerId, Models.Requests.ForwardingRulesList forwardingRules) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", loadBalancerId)
+                Parameter.CreateParameter("id", loadBalancerId, ParameterType.UrlSegment)
             };
 
             return _connection.ExecuteRaw("load_balancers/{id}/forwarding_rules", parameters, forwardingRules, Method.Delete);

--- a/DigitalOcean.API/Clients/ProjectResourcesClient.cs
+++ b/DigitalOcean.API/Clients/ProjectResourcesClient.cs
@@ -19,7 +19,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<ProjectResource>> GetResources(string projectId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("project_id", projectId)
+                Parameter.CreateParameter("project_id", projectId, ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<ProjectResource>("projects/{project_id}/resources", parameters, "resources");
         }
@@ -36,7 +36,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<ProjectResource>> AssignResources(string projectId, AssignResourceNames resources) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("project_id", projectId)
+                Parameter.CreateParameter("project_id", projectId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<List<ProjectResource>>("projects/{project_id}/resources", parameters, resources, "resources", Method.Post)
                 .ToReadOnlyListAsync();

--- a/DigitalOcean.API/Clients/ProjectsClient.cs
+++ b/DigitalOcean.API/Clients/ProjectsClient.cs
@@ -31,7 +31,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Project> Get(string projectId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("project_id", projectId)
+                Parameter.CreateParameter("project_id", projectId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Project>("projects/{project_id}", parameters, null, "project");
         }
@@ -48,7 +48,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Project> Update(string projectId, Models.Requests.UpdateProject updateProject) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("project_id", projectId)
+                Parameter.CreateParameter("project_id", projectId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Project>("projects/{project_id}", parameters, updateProject, "project", Method.Put);
         }
@@ -67,7 +67,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Project> Patch(string projectId, Models.Requests.PatchProject patchProject) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("project_id", projectId)
+                Parameter.CreateParameter("project_id", projectId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Project>("projects/{project_id}", parameters, patchProject, "project", Method.Patch);
         }
@@ -87,7 +87,7 @@ namespace DigitalOcean.API.Clients {
         public Task Delete(string projectId)
         {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("project_id", projectId)
+                Parameter.CreateParameter("project_id", projectId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("projects/{project_id}", parameters, null, Method.Delete);
         }

--- a/DigitalOcean.API/Clients/SnapshotsClient.cs
+++ b/DigitalOcean.API/Clients/SnapshotsClient.cs
@@ -39,7 +39,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Snapshot> Get(string snapshotId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("snapshot_id", snapshotId)
+                Parameter.CreateParameter("snapshot_id", snapshotId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Snapshot>("snapshots/{snapshot_id}", parameters, null, "snapshot");
         }
@@ -49,7 +49,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string snapshotId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("snapshot_id", snapshotId)
+                Parameter.CreateParameter("snapshot_id", snapshotId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("snapshots/{snapshot_id}", parameters, null, Method.Delete);
         }

--- a/DigitalOcean.API/Clients/TagsClient.cs
+++ b/DigitalOcean.API/Clients/TagsClient.cs
@@ -26,7 +26,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Tag> Get(string tagName) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("name", tagName)
+                Parameter.CreateParameter("name", tagName, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Tag>("tags/{name}", parameters, null, "tag");
         }
@@ -47,7 +47,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Tag(string tagName, Models.Requests.TagResources resources) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("name", tagName)
+                Parameter.CreateParameter("name", tagName, ParameterType.UrlSegment)
             };
 
             return _connection.ExecuteRaw("tags/{name}/resources", parameters, resources, Method.Post);
@@ -58,7 +58,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Untag(string tagName, Models.Requests.TagResources resources) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("name", tagName)
+                Parameter.CreateParameter("name", tagName, ParameterType.UrlSegment)
             };
 
             return _connection.ExecuteRaw("tags/{name}/resources", parameters, resources, Method.Delete);
@@ -69,7 +69,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string tagName) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("name", tagName)
+                Parameter.CreateParameter("name", tagName, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("tags/{name}", parameters, null, Method.Delete);
         }

--- a/DigitalOcean.API/Clients/VolumeActionsClient.cs
+++ b/DigitalOcean.API/Clients/VolumeActionsClient.cs
@@ -19,7 +19,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Attach(string volumeId, long dropletId, string volumeRegion) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", volumeId)
+                Parameter.CreateParameter("id", volumeId, ParameterType.UrlSegment)
             };
             var body = new Models.Requests.VolumeAction {
                 Type = "attach",
@@ -47,7 +47,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Detach(string volumeId, long dropletId, string volumeRegion) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", volumeId)
+                Parameter.CreateParameter("id", volumeId, ParameterType.UrlSegment)
             };
             var body = new Models.Requests.VolumeAction {
                 Type = "detach",
@@ -75,8 +75,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> GetAction(string volumeId, long actionId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", volumeId),
-                new UrlSegmentParameter("actionId", actionId.ToString())
+                Parameter.CreateParameter("id", volumeId, ParameterType.UrlSegment),
+                Parameter.CreateParameter("actionId", actionId.ToString(), ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Action>("volumes/{id}/actions/{actionId}", parameters, null, "action");
         }
@@ -86,7 +86,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Action>> GetActions(string volumeId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", volumeId)
+                Parameter.CreateParameter("id", volumeId, ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<Action>("volumes/{id}/actions", parameters, "action");
         }
@@ -96,7 +96,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Resize(string volumeId, int sizeGigabytes, string volumeRegion) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", volumeId)
+                Parameter.CreateParameter("id", volumeId, ParameterType.UrlSegment)
             };
             var body = new Models.Requests.VolumeAction {
                 Type = "resize",

--- a/DigitalOcean.API/Clients/VolumesClient.cs
+++ b/DigitalOcean.API/Clients/VolumesClient.cs
@@ -26,7 +26,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Snapshot> CreateSnapshot(string volumeId, Models.Requests.VolumeSnapshot snapshot) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", volumeId)
+                Parameter.CreateParameter("id", volumeId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Snapshot>("volumes/{id}/snapshots", parameters, snapshot, "snapshot", Method.Post);
         }
@@ -36,7 +36,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string volumeId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", volumeId)
+                Parameter.CreateParameter("id", volumeId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("volumes/{id}", parameters, null, Method.Delete);
         }
@@ -57,7 +57,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Volume> Get(string volumeId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", volumeId)
+                Parameter.CreateParameter("id", volumeId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Volume>("volumes/{id}", parameters, null, "volume");
         }
@@ -85,7 +85,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Snapshot>> GetSnapshots(string volumeId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", volumeId)
+                Parameter.CreateParameter("id", volumeId, ParameterType.UrlSegment)
             };
             return _connection.GetPaginated<Snapshot>("volumes/{id}/snapshots", parameters, "snapshots");
         }

--- a/DigitalOcean.API/Clients/VpcClient.cs
+++ b/DigitalOcean.API/Clients/VpcClient.cs
@@ -32,7 +32,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Vpc> Get(string vpcId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter("id", vpcId)
+                Parameter.CreateParameter("id", vpcId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Vpc>("vpcs/{id}", parameters, null, "vpc");
         }
@@ -45,7 +45,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string vpcId) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", vpcId)
+                Parameter.CreateParameter("id", vpcId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRaw("vpcs/{id}", parameters, null, Method.Delete);
         }
@@ -57,7 +57,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Vpc> Update(string vpcId, Models.Requests.UpdateVpc updateVpc) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", vpcId)
+                Parameter.CreateParameter("id", vpcId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Vpc>("vpcs/{id}", parameters, updateVpc, "vpc", Method.Put);
         }
@@ -68,7 +68,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Vpc> PartialUpdate(string vpcId, Models.Requests.UpdateVpc updateVpc) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", vpcId)
+                Parameter.CreateParameter("id", vpcId, ParameterType.UrlSegment)
             };
             return _connection.ExecuteRequest<Vpc>("vpcs/{id}", parameters, updateVpc, "vpc", Method.Patch);
         }
@@ -79,7 +79,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<VpcMember>> ListMembers(string vpcId, string resourceType = null) {
             var parameters = new List<Parameter> {
-                new UrlSegmentParameter ("id", vpcId)
+                Parameter.CreateParameter("id", vpcId, ParameterType.UrlSegment)
             };
             if (!String.IsNullOrEmpty(resourceType)) {
                 parameters.Add(new QueryParameter("resource_type", resourceType));


### PR DESCRIPTION
use Parameter.CreateParameter() factory to create UrlSegmentParameters
ABI breaking change in UrlSegmentParameter constructor (113.0.0) makes it impossible to use new RestSharps

Allows maintaing usage of older RestSharps if needed. As in v113.0.0 explicit net6 support was dropped. Probably why making a breaking change to the UrlSegmentParameter constructor was a non-issue.