### PR TITLE
Package name change

### DIFF
--- a/DigitalOcean.API/DigitalOcean.API.csproj
+++ b/DigitalOcean.API/DigitalOcean.API.csproj
@@ -5,7 +5,7 @@
     <Authors>vevix</Authors>
     <Description>.NET wrapper of the DigitalOcean API</Description>
     <Copyright>2019</Copyright>
-    <PackageId>DigitalOcean.API</PackageId>
+    <PackageId>DigitalOcean.API.Millicast</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>http://i.imgur.com/llqIpX6.png</PackageIconUrl>
     <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
Change package name to `DigitalOcean.API.Millicast`. Will now build non-prerelease versions for cleaner separation of fixes from upstream package (now fully unmaintained).